### PR TITLE
initial idea of ExternalLinks

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,22 @@
+{
+  "background.enabled": true,
+  "background.loop": false,
+  "background.useDefault": false,
+  "background.useFront": false,
+  "background.customImages": [
+    "https://images.unsplash.com/photo-1513106580091-1d82408b8cd6",
+    "https://images.unsplash.com/photo-1536440136628-849c177e76a1?ixlib=rb-1.2.1&ixid=MnwxMjA3fDB8MHxwaG90by1wYWdlfHx8fGVufDB8fHx8&auto=format&fit=crop&w=1925&q=80"
+  ],
+  "background.style": {
+    "content": "''",
+    "pointer-events": "none",
+    "position": "absolute",
+    "z-index": "99999",
+    "width": "100%",
+    "height": "100%",
+    "background-position": "right",
+    "background-size": "cover",
+    "background-repeat": "no-repeat",
+    "opacity": 0.15
+  }
+}

--- a/models/ExternalLinks.model.js
+++ b/models/ExternalLinks.model.js
@@ -1,0 +1,33 @@
+const { Schema } = require('mongoose')
+const Movie = require('./Movie.model')
+const Cinema = require('./Cinema.model')
+
+const linkSchema = new Schema({
+  source: {
+    type: String,
+    enum: ['TMDB', 'Allocine'],
+    required: true,
+  },
+  externalId: { type: Schema.Types.String, required: true },
+  confirmed: { type: Schema.Types.Boolean, default: false },
+  // A number 0-100 used for ordering multiple possible links
+  likelihood: { type: Schema.Types.Number, default: 50 },
+})
+
+const movieLinkSchema = new Schema({
+  movie: { type: Schema.Types.ObjectId, ref: Movie, required: true },
+})
+
+const cinemaLinkSchema = new Schema({
+  cinema: { type: Schema.Types.ObjectId, ref: Cinema, required: true },
+})
+
+const ExternalLink = mongoose.model('Link', linkSchema)
+const ExternalMovieLink = Link.discriminator('movie', movieLinkSchema)
+const ExternalCinemaLink = Link.discriminator('cinema', cinemaLinkSchema)
+
+module.exports = {
+  ExternalLink,
+  ExternalMovieLink,
+  ExternalCinemaLink,
+}


### PR DESCRIPTION
External links are for mapping from a Ciaocine `Movie` document to an external id, be it:

- letterboxd
- allocine
- TMDB

These links can be marked as `confirmed` when they're known to be correct. Until then, they exist for checking purposes.

A further field of `likelihood` can be used to give an indication of how likely an unconfirmed match is to be correct. This can be a score out of 100, which uses the movie's name, year, director, and any other information available.

It's possible also to have a link between TMDB and Letterboxd which is 100% confirmed, so perhaps we should take TMDB to be the ExternalLink, and we can link to a Letterboxd ID via that.

Recording Letterboxd identifiers will make it possible to import a watchlist and diary entries from Letterboxd, and later link them.